### PR TITLE
Refactor Method Name and Improve HTTP Header Handling in ServiceManager

### DIFF
--- a/render_cdk/src/main.rs
+++ b/render_cdk/src/main.rs
@@ -21,7 +21,7 @@ async fn main() {
     // let services = ServiceManager::list_all_services("50").await;
 
     // List all Services that are suspended/not_suspended.
-    let services = ServiceManager::list_all_suspended_services("suspended", "50").await;
+    let services = ServiceManager::list_services_with_status("suspended", "50").await;
 
     // List all Services by Name and Type.
     // let services = ServiceManager::find_service_by_name_and_type("whoami", "web_service").await;
@@ -190,6 +190,17 @@ mod regression_tests {
 
         // Validate content.
         let services = result.unwrap();
+        assert!(!services.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_services_with_status() {
+        let results = ServiceManager::list_services_with_status("suspended", "10").await;
+        // The result should be Ok().
+        assert!(results.is_ok());
+
+        // Validate content.
+        let services = results.unwrap();
         assert!(!services.is_empty());
     }
 

--- a/render_cdk/src/resource_management/services/service_manager.rs
+++ b/render_cdk/src/resource_management/services/service_manager.rs
@@ -25,7 +25,7 @@ pub trait ServiceManagerOperations {
     fn list_all_services(
         limit: &str,
     ) -> impl std::future::Future<Output = Result<String, Error>> + Send;
-    fn list_all_suspended_services(
+    fn list_services_with_status(
         service_status: &str,
         limit: &str,
     ) -> impl std::future::Future<Output = Result<String, Error>> + Send;
@@ -98,7 +98,7 @@ impl ServiceManagerOperations for ServiceManager {
 
     /// Finding all suspended services.
     /// Reqquired arguments: <service_status> i.e suspended/not_suspended.
-    async fn list_all_suspended_services(
+    async fn list_services_with_status(
         service_status: &str,
         limit: &str,
     ) -> Result<String, Error> {
@@ -180,8 +180,8 @@ impl ServiceManagerOperations for ServiceManager {
 
         let response = client
             .get(api_url)
-            .header("ACCEPT", "application/json")
-            .header("AUTHORIZATION", format!("Bearer {}", api_key))
+            .header(ACCEPT, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", api_key))
             .send()
             .await
             .context("Error sending request.")?;
@@ -228,8 +228,8 @@ impl ServiceManagerOperations for ServiceManager {
 
         let response = client
             .get(api_url)
-            .header("ACCEPT", "application/json")
-            .header("AUTHORIZATION", format!("Bearer {}", api_key))
+            .header(ACCEPT, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", api_key))
             .send()
             .await
             .context("Error sending request.")?;
@@ -275,8 +275,8 @@ impl ServiceManagerOperations for ServiceManager {
         //////////////////////////////
         let response = client
             .get(api_url)
-            .header("ACCEPT", "application/json")
-            .header("AUTHORIZATION", format!("Bearer {}", api_key))
+            .header(ACCEPT, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", api_key))
             .send()
             .await
             .context("Error sending request.")?;
@@ -342,9 +342,9 @@ impl ServiceManagerOperations for ServiceManager {
 
         let response = client
             .post(api_url)
-            .header("ACCEPT", "application/json")
-            .header("CONTENT-TYPE", "application/json")
-            .header("AUTHORIZATION", format!("Bearer {}", api_key))
+            .header(ACCEPT, "application/json")
+            .header(CONTENT_TYPE, "application/json")
+            .header(AUTHORIZATION, format!("Bearer {}", api_key))
             .body(payload)
             .send()
             .await


### PR DESCRIPTION
### Changes
-   **Renamed Method**:
    
    -   The method `list_all_suspended_services` has been renamed to `list_services_with_status` to better reflect its functionality of returning services based on their status, whether suspended or not.
-   **Updated Main Function**:
    
    -   Modified the call in `main.rs` to use the updated method name.
-   **Added Test Case**:
    
    -   Introduced a new test case `test_list_services_with_status` to validate the functionality of the renamed method.
-   **Header Constants**:
    
    -   Replaced string literals for HTTP headers with constants (`ACCEPT`, `AUTHORIZATION`, `CONTENT_TYPE`) in multiple places within `service_manager.rs` for consistency and maintainability.